### PR TITLE
Pocket Domain UseCase 정의

### DIFF
--- a/internal/app/pocket/usecase/pocket_usecase.go
+++ b/internal/app/pocket/usecase/pocket_usecase.go
@@ -1,0 +1,172 @@
+package usecase
+
+import (
+	"context"
+	"github.com/lucky-pocket/luckyPocket-back/internal/domain"
+	"github.com/lucky-pocket/luckyPocket-back/internal/domain/data/input"
+	"github.com/lucky-pocket/luckyPocket-back/internal/domain/data/output"
+	"github.com/lucky-pocket/luckyPocket-back/internal/domain/data/output/mapper"
+	"github.com/lucky-pocket/luckyPocket-back/internal/global/auth"
+	"github.com/pkg/errors"
+)
+
+type Deps struct {
+	UserRepository   domain.UserRepository
+	PocketRepository domain.PocketRepository
+}
+
+type pocketUseCase struct{ *Deps }
+
+func (p *pocketUseCase) GetUserPockets(ctx context.Context, input *input.UserIDInput, pageInput input.PageInput) (*output.PocketListOutput, error) {
+	user, err := p.UserRepository.FindByID(ctx, input.UserID)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "unexpected db error")
+	}
+
+	if user == nil {
+		return nil, errors.Wrap(err, "user not found")
+	}
+
+	pockets, err2 := p.PocketRepository.FindListByUserID(ctx, input.UserID, pageInput.Offset, pageInput.Limit)
+
+	if err2 != nil {
+		return nil, errors.Wrap(err2, "unexpected db error")
+	}
+
+	return mapper.ToPocketListOutput(pockets), nil
+}
+
+func NewPocketUseCase(deps *Deps) domain.PocketUseCase {
+	return &pocketUseCase{deps}
+}
+
+func (p *pocketUseCase) SendPocket(ctx context.Context, input *input.PocketInput) error {
+	userInfo := auth.MustExtract(ctx)
+
+	currentUser, err := p.UserRepository.FindByID(ctx, userInfo.UserID)
+	receiver, err2 := p.UserRepository.FindByName(ctx, input.Receiver)
+
+	if currentUser == nil && receiver == nil {
+		return errors.Wrap(err, "user not found")
+	}
+
+	if err != nil && err2 != nil {
+		return errors.Wrap(err, "unexpected db error")
+	}
+
+	pocket := domain.Pocket{
+		Receiver: receiver,
+		Sender:   currentUser,
+		Content:  input.Message,
+		Coins:    input.Coins,
+		IsPublic: input.IsPublic,
+	}
+
+	err3 := p.PocketRepository.Create(ctx, &pocket)
+
+	if err3 != nil {
+		return errors.Wrap(err3, "unexpected db error")
+	}
+
+	switch input.IsPublic {
+	case true:
+		err4 := p.UserRepository.SaveReveal(ctx, currentUser.UserID, pocket.PocketID)
+
+		if err4 != nil {
+			return errors.Wrap(err3, "unexpected db error")
+		}
+		break
+	default:
+		break
+	}
+
+	return nil
+}
+
+func (p *pocketUseCase) RevealSender(ctx context.Context, input *input.PocketIDInput) error {
+	userInfo := auth.MustExtract(ctx)
+
+	currentUser, err := p.UserRepository.FindByID(ctx, userInfo.UserID)
+	pocket, err2 := p.PocketRepository.FindByID(ctx, input.PocketID)
+
+	if currentUser == nil && pocket == nil {
+		return errors.Wrap(err, "user not found")
+	}
+
+	if err != nil && err2 != nil {
+		return errors.Wrap(err, "unexpected db error")
+	}
+
+	if pocket.Receiver != currentUser {
+		return errors.Wrap(err, "not allowed permission this pocket")
+	}
+
+	exists, err3 := p.UserRepository.ExistsReveal(ctx, currentUser.UserID, pocket.PocketID)
+
+	if err3 != nil {
+		return errors.Wrap(err3, "unexpected db error")
+	}
+
+	if exists {
+		return errors.Wrap(err3, "exists reveal")
+	}
+
+	err = p.UserRepository.SaveReveal(ctx, currentUser.UserID, pocket.PocketID)
+
+	if err != nil {
+		return errors.Wrap(err, "unexpected db error")
+	}
+
+	coin := currentUser.Coins
+	err = p.UserRepository.UpdateCoin(ctx, currentUser.UserID, coin-1)
+
+	if err != nil {
+		return errors.Wrap(err, "unexpected db error")
+	}
+
+	return nil
+}
+
+func (p *pocketUseCase) GetPocketDetail(ctx context.Context, input *input.PocketIDInput) (*output.PocketOutput, error) {
+	pocket, err := p.PocketRepository.FindByID(ctx, input.PocketID)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "unexpected db error")
+	}
+
+	if pocket == nil {
+		return nil, errors.Wrap(err, "pocket not found")
+	}
+
+	isPublic, err2 := p.UserRepository.ExistsReveal(ctx, pocket.Receiver.UserID, pocket.PocketID)
+
+	if err2 != nil {
+		return nil, errors.Wrap(err2, "unexpected db error")
+	}
+
+	return mapper.ToPocketOutput(pocket, isPublic), nil
+}
+
+func (p *pocketUseCase) SetVisibility(ctx context.Context, input *input.VisibilityInput) error {
+	userInfo := auth.MustExtract(ctx)
+
+	currentUser, err := p.UserRepository.FindByID(ctx, userInfo.UserID)
+	pocket, err2 := p.PocketRepository.FindByID(ctx, input.PocketID)
+
+	if currentUser == nil || pocket == nil {
+		return errors.Wrap(err, "not found error")
+	}
+
+	if err != nil && err2 != nil {
+		return errors.Wrap(err, "unexpected db error")
+	}
+
+	if pocket.Receiver == currentUser {
+		p.PocketRepository.UpdateVisible(ctx, pocket.PocketID, input.Visible)
+	} else {
+		return errors.Wrap(err2, "not allowed permission this pocket")
+	}
+
+	return nil
+}

--- a/internal/app/pocket/usecase/pocket_usecase.go
+++ b/internal/app/pocket/usecase/pocket_usecase.go
@@ -164,6 +164,10 @@ func (p *pocketUseCase) SetVisibility(ctx context.Context, input *input.Visibili
 		return errors.Wrap(err2, "not allowed permission this pocket")
 	}
 
-	p.PocketRepository.UpdateVisible(ctx, pocket.PocketID, input.Visible)
+	err = p.PocketRepository.UpdateVisibility(ctx, pocket.PocketID, input.Visible)
+
+	if err != nil {
+		return errors.Wrap(err, "unexpected db error")
+	}
 	return nil
 }

--- a/internal/app/pocket/usecase/pocket_usecase.go
+++ b/internal/app/pocket/usecase/pocket_usecase.go
@@ -67,14 +67,10 @@ func (p *pocketUseCase) SendPocket(ctx context.Context, input *input.PocketInput
 		return errors.Wrap(err, "unexpected db error")
 	}
 
-	switch input.IsPublic {
-	case true:
-		err4 := p.UserRepository.SaveReveal(ctx, currentUser.UserID, pocket.PocketID)
-
-		if err4 != nil {
+	if input.IsPublic {
+		if err := p.UserRepository.SaveReveal(ctx, currentUser.UserID, pocket.PocketID); err != nil {
 			return errors.Wrap(err3, "unexpected db error")
 		}
-	default:
 	}
 
 	return nil

--- a/internal/app/pocket/usecase/pocket_usecase.go
+++ b/internal/app/pocket/usecase/pocket_usecase.go
@@ -20,7 +20,6 @@ type pocketUseCase struct{ *Deps }
 
 func (p *pocketUseCase) GetUserPockets(ctx context.Context, input *input.UserIDInput, pageInput input.PageInput) (*output.PocketListOutput, error) {
 	user, err := p.UserRepository.FindByID(ctx, input.UserID)
-
 	if err != nil {
 		return nil, errors.Wrap(err, "unexpected db error")
 	}

--- a/internal/app/pocket/usecase/pocket_usecase.go
+++ b/internal/app/pocket/usecase/pocket_usecase.go
@@ -63,10 +63,8 @@ func (p *pocketUseCase) SendPocket(ctx context.Context, input *input.PocketInput
 		IsPublic: input.IsPublic,
 	}
 
-	err3 := p.PocketRepository.Create(ctx, &pocket)
-
-	if err3 != nil {
-		return errors.Wrap(err3, "unexpected db error")
+	if err := p.PocketRepository.Create(ctx, &pocket); err != nil {
+		return errors.Wrap(err, "unexpected db error")
 	}
 
 	switch input.IsPublic {

--- a/internal/app/pocket/usecase/pocket_usecase.go
+++ b/internal/app/pocket/usecase/pocket_usecase.go
@@ -76,9 +76,7 @@ func (p *pocketUseCase) SendPocket(ctx context.Context, input *input.PocketInput
 		if err4 != nil {
 			return errors.Wrap(err3, "unexpected db error")
 		}
-		break
 	default:
-		break
 	}
 
 	return nil
@@ -162,11 +160,10 @@ func (p *pocketUseCase) SetVisibility(ctx context.Context, input *input.Visibili
 		return errors.Wrap(err, "unexpected db error")
 	}
 
-	if pocket.Receiver == currentUser {
-		p.PocketRepository.UpdateVisible(ctx, pocket.PocketID, input.Visible)
-	} else {
+	if pocket.Receiver != currentUser {
 		return errors.Wrap(err2, "not allowed permission this pocket")
 	}
 
+	p.PocketRepository.UpdateVisible(ctx, pocket.PocketID, input.Visible)
 	return nil
 }

--- a/internal/app/pocket/usecase/pocket_usecase.go
+++ b/internal/app/pocket/usecase/pocket_usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	
 	"github.com/lucky-pocket/luckyPocket-back/internal/domain"
 	"github.com/lucky-pocket/luckyPocket-back/internal/domain/data/input"
 	"github.com/lucky-pocket/luckyPocket-back/internal/domain/data/output"

--- a/internal/app/pocket/usecase/pocket_usecase.go
+++ b/internal/app/pocket/usecase/pocket_usecase.go
@@ -29,10 +29,10 @@ func (p *pocketUseCase) GetUserPockets(ctx context.Context, input *input.UserIDI
 		return nil, errors.Wrap(err, "user not found")
 	}
 
-	pockets, err2 := p.PocketRepository.FindListByUserID(ctx, input.UserID, pageInput.Offset, pageInput.Limit)
+	pockets, err := p.PocketRepository.FindListByUserID(ctx, input.UserID, pageInput.Offset, pageInput.Limit)
 
-	if err2 != nil {
-		return nil, errors.Wrap(err2, "unexpected db error")
+	if err != nil {
+		return nil, errors.Wrap(err, "unexpected db error")
 	}
 
 	return mapper.ToPocketListOutput(pockets), nil

--- a/internal/domain/data/input/pocket_input.go
+++ b/internal/domain/data/input/pocket_input.go
@@ -20,7 +20,8 @@ type PocketIDInput struct {
 	PocketID uint64
 }
 
-type PageInput struct {
+type Input struct {
+	UserID uint64
 	Offset int
 	Limit  int
 }

--- a/internal/domain/data/input/pocket_input.go
+++ b/internal/domain/data/input/pocket_input.go
@@ -4,6 +4,7 @@ type PocketInput struct {
 	Receiver string
 	Coins    int
 	Message  string
+	IsPublic bool
 }
 
 type UserIDInput struct {
@@ -17,4 +18,9 @@ type VisibilityInput struct {
 
 type PocketIDInput struct {
 	PocketID uint64
+}
+
+type PageInput struct {
+	Offset int
+	Limit  int
 }

--- a/internal/domain/data/output/mapper/pocket_mapper.go
+++ b/internal/domain/data/output/mapper/pocket_mapper.go
@@ -9,9 +9,7 @@ func ToPocketListOutput(pocketList []*domain.Pocket) *output.PocketListOutput {
 	pockets := &output.PocketListOutput{}
 
 	for _, p := range pocketList {
-
 		isEmpty := true
-
 		if p.Coins == 0 {
 			isEmpty = true
 		} else {
@@ -31,7 +29,7 @@ func ToPocketListOutput(pocketList []*domain.Pocket) *output.PocketListOutput {
 }
 
 func ToPocketOutput(pocket *domain.Pocket, isPublic bool) *output.PocketOutput {
-	userInfo := &output.UserInfo{}
+	var userInfo *output.UserInfo
 
 	if isPublic {
 		sender := pocket.Sender.Name

--- a/internal/domain/data/output/mapper/pocket_mapper.go
+++ b/internal/domain/data/output/mapper/pocket_mapper.go
@@ -1,0 +1,51 @@
+package mapper
+
+import (
+	"github.com/lucky-pocket/luckyPocket-back/internal/domain"
+	"github.com/lucky-pocket/luckyPocket-back/internal/domain/data/output"
+)
+
+func ToPocketListOutput(pocketList []*domain.Pocket) *output.PocketListOutput {
+	pockets := &output.PocketListOutput{}
+
+	for _, p := range pocketList {
+
+		isEmpty := true
+
+		if p.Coins == 0 {
+			isEmpty = true
+		} else {
+			isEmpty = false
+		}
+
+		elem := output.PocketElem{
+			PocketID: p.PocketID,
+			IsEmpty:  isEmpty,
+			IsPublic: p.IsPublic,
+		}
+
+		pockets.Pockets = append(pockets.Pockets, elem)
+	}
+
+	return pockets
+}
+
+func ToPocketOutput(pocket *domain.Pocket, isPublic bool) *output.PocketOutput {
+	userInfo := &output.UserInfo{}
+
+	if isPublic {
+		sender := pocket.Sender.Name
+		userInfo = &output.UserInfo{
+			UserID: pocket.Sender.UserID,
+			Name:   sender,
+		}
+	} else {
+		userInfo = nil
+	}
+
+	return &output.PocketOutput{
+		Content: pocket.Content,
+		Coins:   pocket.Coins,
+		Sender:  userInfo,
+	}
+}

--- a/internal/domain/pocket.go
+++ b/internal/domain/pocket.go
@@ -32,5 +32,5 @@ type PocketRepository interface {
 	Create(ctx context.Context, pocket *Pocket) error
 	FindByID(ctx context.Context, pocketID uint64) (*Pocket, error)
 	FindListByUserID(ctx context.Context, userID uint64, offset, limit int) ([]*Pocket, error)
-	UpdateVisible(ctx context.Context, pocketID uint64, visible bool)
+	UpdateVisibility(ctx context.Context, pocketID uint64, visible bool) error
 }

--- a/internal/domain/pocket.go
+++ b/internal/domain/pocket.go
@@ -23,7 +23,7 @@ func (p Pocket) IsEmpty() bool {
 type PocketUseCase interface {
 	SendPocket(ctx context.Context, input *input.PocketInput) error
 	RevealSender(ctx context.Context, input *input.PocketIDInput) error
-	GetUserPockets(ctx context.Context, input *input.UserIDInput, pageInput input.PageInput) (*output.PocketListOutput, error)
+	GetUserPockets(ctx context.Context, input *input.Input) (*output.PocketListOutput, error)
 	GetPocketDetail(ctx context.Context, input *input.PocketIDInput) (*output.PocketOutput, error)
 	SetVisibility(ctx context.Context, input *input.VisibilityInput) error
 }

--- a/internal/domain/pocket.go
+++ b/internal/domain/pocket.go
@@ -13,6 +13,7 @@ type Pocket struct {
 	Sender   *User
 	Content  string
 	Coins    int
+	IsPublic bool
 }
 
 func (p Pocket) IsEmpty() bool {
@@ -21,8 +22,8 @@ func (p Pocket) IsEmpty() bool {
 
 type PocketUseCase interface {
 	SendPocket(ctx context.Context, input *input.PocketInput) error
-	RevealSender(ctx context.Context, input *input.UserIDInput) error
-	GetUserPockets(ctx context.Context, input *input.UserIDInput) (*output.PocketListOutput, error)
+	RevealSender(ctx context.Context, input *input.PocketIDInput) error
+	GetUserPockets(ctx context.Context, input *input.UserIDInput, pageInput input.PageInput) (*output.PocketListOutput, error)
 	GetPocketDetail(ctx context.Context, input *input.PocketIDInput) (*output.PocketOutput, error)
 	SetVisibility(ctx context.Context, input *input.VisibilityInput) error
 }
@@ -31,4 +32,5 @@ type PocketRepository interface {
 	Create(ctx context.Context, pocket *Pocket) error
 	FindByID(ctx context.Context, pocketID uint64) (*Pocket, error)
 	FindListByUserID(ctx context.Context, userID uint64, offset, limit int) ([]*Pocket, error)
+	UpdateVisible(ctx context.Context, pocketID uint64, visible bool)
 }

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -39,4 +39,8 @@ type UserRepository interface {
 	FindStudentsWithFilter(ctx context.Context, sortType constant.SortType, name *string, grade, class *int) ([]output.RankElem, error)
 	FindNonStudentWithFilter(ctx context.Context, sortType constant.SortType, name *string) ([]output.RankElem, error)
 	CountCoinsByUserID(ctx context.Context, userID uint64) (int, error)
+	FindByName(ctx context.Context, name string) (*User, error)
+	UpdateCoin(ctx context.Context, userID uint64, coin int) error
+	SaveReveal(ctx context.Context, userID uint64, pocketID uint64) error
+	ExistsReveal(ctx context.Context, userID uint64, pocketID uint64) (bool, error)
 }


### PR DESCRIPTION
# summary
- pocket domain의 usecase를 정의합니다
# changes
- pocket usecase 작성
- pocket mapper 추가
# etc
- 필요한 repoistory method 추가
- 필요한 output, input field 추가


close #25 